### PR TITLE
Dev

### DIFF
--- a/templates/sophos.template
+++ b/templates/sophos.template
@@ -649,7 +649,7 @@ Mappings:
       QueenInstanceType: c4.large
       SwarmInstanceType: c4.large
     ap-southeast-2:
-      AmazonAMI: ami-0a10b2721688ce9d2
+      AmazonAMI: ami-09b42976632b27e9b
       OGWAMI: ami-094f46f1d48a9dec1
       Hourly: ami-058ef66bf58423e72
       BYOL: ami-014532b8ccf0a673c

--- a/templates/sophos.template
+++ b/templates/sophos.template
@@ -617,122 +617,122 @@ Metadata:
 Mappings:
   RegionMap:
     ap-northeast-1:
-      AmazonAMI: ami-ceafcba8
-      OGWAMI: ami-e4941682
-      Hourly: ami-73972f15
-      BYOL: ami-47922a21
+      AmazonAMI: ami-06cd52961ce9f0d85
+      OGWAMI: ami-0189eea3a673530fe
+      Hourly: ami-051d6d388a5a789f0
+      BYOL: ami-0927f2c574618ea85
       ARN: aws
       QueenInstanceType: c4.large
       SwarmInstanceType: c4.large
     ap-northeast-2:
-      AmazonAMI: ami-863090e8
-      OGWAMI: ami-bd50f6d3
-      Hourly: ami-110daa7f
-      BYOL: ami-9900a7f7
+      AmazonAMI: ami-0a10b2721688ce9d2
+      OGWAMI: ami-032565bddf1a879c1
+      Hourly: ami-0e51730dc0b79098a
+      BYOL: ami-0af85fc5b6e8303d8
       ARN: aws
       QueenInstanceType: c4.large
       SwarmInstanceType: c4.large
     ap-south-1:
-      AmazonAMI: ami-531a4c3c
-      OGWAMI: ami-eabff785
-      Hourly: ami-fbc78994
-      BYOL: ami-fac78995
+      AmazonAMI: ami-0912f71e06545ad88
+      OGWAMI: ami-08cbce4d5146ad7d7
+      Hourly: ami-070e846716982c64e
+      BYOL: ami-0539befa542758313
       ARN: aws
       QueenInstanceType: c4.large
       SwarmInstanceType: c4.large
     ap-southeast-1:
-      AmazonAMI: ami-68097514
-      OGWAMI: ami-d72a4aab
-      Hourly: ami-db1a48b8
-      BYOL: ami-8c1a48ef
+      AmazonAMI: ami-08569b978cc4dfa10
+      OGWAMI: ami-008354309002142cc
+      Hourly: ami-0b72d851deee20a07
+      BYOL: ami-093e2be101135a789
       ARN: aws
       QueenInstanceType: c4.large
       SwarmInstanceType: c4.large
     ap-southeast-2:
-      AmazonAMI: ami-942dd1f6
-      OGWAMI: ami-38a3555a
-      Hourly: ami-2d36c34f
-      BYOL: ami-8d34c1ef
+      AmazonAMI: ami-0a10b2721688ce9d2
+      OGWAMI: ami-094f46f1d48a9dec1
+      Hourly: ami-058ef66bf58423e72
+      BYOL: ami-014532b8ccf0a673c
       ARN: aws
       QueenInstanceType: c4.large
       SwarmInstanceType: c4.large
     ca-central-1:
-      AmazonAMI: ami-a954d1cd
-      OGWAMI: ami-2cbb0148
-      Hourly: ami-3249f256
-      BYOL: ami-6248f306
+      AmazonAMI: ami-0b18956f
+      OGWAMI: ami-0d7d57ef88f4ea222
+      Hourly: ami-0e9294efc262bbbef
+      BYOL: ami-0277885ef01abeac4
       ARN: aws
       QueenInstanceType: c4.large
       SwarmInstanceType: c4.large
     eu-central-1:
-      AmazonAMI: ami-5652ce39
-      OGWAMI: ami-e8d45f87
-      Hourly: ami-df79f5b0
-      BYOL: ami-71ec4c1e
+      AmazonAMI: ami-0233214e13e500f77
+      OGWAMI: ami-01d2476f545349abd
+      Hourly: ami-04c95b25042d680bc
+      BYOL: ami-0a244f10ac6ea610d
       ARN: aws
       QueenInstanceType: c4.large
       SwarmInstanceType: c4.large
     eu-west-1:
-      AmazonAMI: ami-d834aba1
-      OGWAMI: ami-71088d08
-      Hourly: ami-bea113c7
-      BYOL: ami-01a31178
+      AmazonAMI: ami-047bb4163c506cd98
+      OGWAMI: ami-0fca50ef5a9fb3ec2
+      Hourly: ami-08b98abc8f00ebc7e
+      BYOL: ami-0c476d65f9bc127a2
       ARN: aws
       QueenInstanceType: c4.large
       SwarmInstanceType: c4.large
     eu-west-2:
-      AmazonAMI: ami-403e2524
-      OGWAMI: ami-a45148c0
-      Hourly: ami-c24658a6
-      BYOL: ami-b14759d5
+      AmazonAMI: ami-f976839e
+      OGWAMI: ami-05f83b31a6d1365db
+      Hourly: ami-0cf3f68ef9fa1a09a
+      BYOL: ami-025cf9a26106b991f
       ARN: aws
       QueenInstanceType: c4.large
       SwarmInstanceType: c4.large
     sa-east-1:
-      AmazonAMI: ami-84175ae8
-      OGWAMI: ami-b66f29da
-      Hourly: ami-8a85c1e6
-      BYOL: ami-ae84c0c2
+      AmazonAMI: ami-07b14488da8ea02a0
+      OGWAMI: ami-0622432257bd2d416
+      Hourly: ami-05e86ccfffe8a3587
+      BYOL: ami-0a1e7ee2dcf864cec
       ARN: aws
       QueenInstanceType: m3.large
       SwarmInstanceType: m3.large
     us-east-1:
-      AmazonAMI: ami-97785bed
-      OGWAMI: ami-4e761c34
-      Hourly: ami-b0920eca
-      BYOL: ami-d1910dab
+      AmazonAMI: ami-0ff8a91507f77f867
+      OGWAMI: ami-03aff3e0eec3f4f40
+      Hourly: ami-0ebe2f382b079b0f0
+      BYOL: ami-001efe65220bb0d37
       ARN: aws
       QueenInstanceType: c4.large
       SwarmInstanceType: c4.large
     us-east-2:
-      AmazonAMI: ami-f63b1193
-      OGWAMI: ami-d86c44bd
-      Hourly: ami-dd634ab8
-      BYOL: ami-6c654c09
+      AmazonAMI: ami-0b59bfac6be064b78
+      OGWAMI: ami-05e8e585c8c631ca6
+      Hourly: ami-0d90f785d9ec3c57c
+      BYOL: ami-0f0127a7881303086
       ARN: aws
       QueenInstanceType: c4.large
       SwarmInstanceType: c4.large
     us-gov-west-1:
-      AmazonAMI: ami-56f87137
-      OGWAMI: ami-ae65eacf
-      Hourly: ami-6fb23e0e
-      BYOL: ami-6fb23e0e
+      AmazonAMI: ami-906cf0f1
+      OGWAMI: ami-6966fc08
+      Hourly: ami-939208f2
+      BYOL: ami-99900af8
       ARN: aws-us-gov
       QueenInstanceType: c4.large
       SwarmInstanceType: c4.large
     us-west-1:
-      AmazonAMI: ami-824c4ee2
-      OGWAMI: ami-2d6f6b4d
-      Hourly: ami-5dba813d
-      BYOL: ami-5cba813c
+      AmazonAMI: ami-0bdb828fd58c52235
+      OGWAMI: ami-0f3cb25a6fd92201a
+      Hourly: ami-05b01290e6784b39a
+      BYOL: ami-0eeec54b31db0b0d8
       ARN: aws
       QueenInstanceType: c4.large
       SwarmInstanceType: c4.large
     us-west-2:
-      AmazonAMI: ami-f2d3638a
-      OGWAMI: ami-bd65c3c5
-      Hourly: ami-9fab72e7
-      BYOL: ami-86aa73fe
+      AmazonAMI: ami-a0cfeed8
+      OGWAMI: ami-0c1bfac5365dc0721
+      Hourly: ami-0e5c88803c9f44351
+      BYOL: ami-0762f3180227c7442
       ARN: aws
       QueenInstanceType: c4.large
       SwarmInstanceType: c4.large


### PR DESCRIPTION
Updated UTM AMI IDs to 9.510, updated OGW AMI ID and EC2 Linux AMI IDs.
Source: https://github.com/sophos-iaas/aws-cf-templates/blob/master/utm/CHANGELOG.md

Taskcat output attached.
[taskcat_outputs.zip](https://github.com/aws-quickstart/quickstart-sophos-outboundproxy/files/2715831/taskcat_outputs.zip)
